### PR TITLE
@username instead of username#0

### DIFF
--- a/cogs/stalking_events.py
+++ b/cogs/stalking_events.py
@@ -291,7 +291,7 @@ class StalkingEvents(vbu.Cog, name="Stalking Events (Message Send/Edit)"):
         color = abs(hash(keyword)) & 0xffffff  #random.randint(0, 0xffffff)
         embed.color = color
         author_payload = {
-                "name": str(message.author),
+                "name": str(message.author) if message.author.discriminator else f"\\@{message.author.username}",
             }
         if (avatar:=message.author.avatar):
                 author_payload["icon_url"] = avatar.url


### PR DESCRIPTION
This change is meant for users who have transitioned to @ usernames instead of gamertags, while still supporting gamertags